### PR TITLE
Enable record ID search in metadata lookup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -196,7 +196,7 @@ def metadata_search(entity_values, vectorstore):
     hits = []
     for doc in all_docs:
         found = False
-        for field in ["dates", "names", "underlined"]:
+        for field in ["dates", "names", "records", "underlined"]:
             meta_values = doc.metadata.get(field, [])
             if isinstance(meta_values, str):
                 meta_values = [meta_values]

--- a/query_documents.py
+++ b/query_documents.py
@@ -38,7 +38,7 @@ def metadata_search(entity_values, vectorstore):
     hits = []
     for doc in all_docs:
         found = False
-        for field in ["dates", "names", "underlined"]:
+        for field in ["dates", "names", "records", "underlined"]:
             # metadata may have these fields as list or string
             meta_values = doc.metadata.get(field, [])
             if isinstance(meta_values, str):


### PR DESCRIPTION
## Summary
- include `records` in metadata search for backend API and CLI

## Testing
- `python -m py_compile backend/main.py query_documents.py`


------
https://chatgpt.com/codex/tasks/task_e_689df39c8a44832ca6696e957f0de8fa