### PR TITLE
feat: add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ A minimal Retrieval-Augmented Generation (RAG) system for document-based questio
    ```
    The API will be available at [http://localhost:8000](http://localhost:8000).
 
+3. **Check server health:**
+   ```bash
+   curl http://localhost:8000/api/health
+   ```
+   Should return a JSON status payload.
+
 ---
 
 ## Frontend Setup (Next.js Dashboard)

--- a/backend/main.py
+++ b/backend/main.py
@@ -40,6 +40,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.get("/api/health")
+async def health_check() -> Dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok", "timestamp": datetime.utcnow().isoformat()}
+
 # Models
 class Message(BaseModel):
     role: str


### PR DESCRIPTION
## Summary
- expose `/api/health` FastAPI endpoint for a lightweight status check
- document how to use the health check in the backend setup guide

## Testing
- `pytest`
- `cd rag-dashboard && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e487eebb8832c82d310f33122f5ff